### PR TITLE
Highlight CSS properties

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -49,6 +49,15 @@ Determines whether text inside `a` tags in HTML files will be underlined.
 
 Default: `1` (on)
 
+### g:badwolf\_css\_props\_highlight
+
+Determines whether CSS properties should be highlighted.
+
+    " Turn on CSS properties highlighting
+    let g:badwolf_css_props_highlight = 1
+
+Default: `0` (off)
+
 Contributing
 ------------
 

--- a/colors/badwolf.vim
+++ b/colors/badwolf.vim
@@ -47,6 +47,10 @@ if !exists("g:badwolf_html_link_underline") " {{{
     let g:badwolf_html_link_underline = 1
 endif " }}}
 
+if !exists("g:badwolf_css_props_highlight") " {{{
+    let g:badwolf_css_props_highlight = 0
+endif " }}}
+
 " }}}
 " Palette {{{
 
@@ -397,11 +401,19 @@ call s:HL('clojureAnonArg', 'snow', '', 'bold')
 " }}}
 " CSS {{{
 
-call s:HL('cssColorProp', 'fg', '', 'none')
-call s:HL('cssBoxProp', 'fg', '', 'none')
-call s:HL('cssTextProp', 'fg', '', 'none')
-call s:HL('cssRenderProp', 'fg', '', 'none')
-call s:HL('cssGeneratedContentProp', 'fg', '', 'none')
+if g:badwolf_css_props_highlight
+    call s:HL('cssColorProp', 'dirtyblonde', '', 'none')
+    call s:HL('cssBoxProp', 'dirtyblonde', '', 'none')
+    call s:HL('cssTextProp', 'dirtyblonde', '', 'none')
+    call s:HL('cssRenderProp', 'dirtyblonde', '', 'none')
+    call s:HL('cssGeneratedContentProp', 'dirtyblonde', '', 'none')
+else
+    call s:HL('cssColorProp', 'fg', '', 'none')
+    call s:HL('cssBoxProp', 'fg', '', 'none')
+    call s:HL('cssTextProp', 'fg', '', 'none')
+    call s:HL('cssRenderProp', 'fg', '', 'none')
+    call s:HL('cssGeneratedContentProp', 'fg', '', 'none')
+end
 
 call s:HL('cssValueLength', 'toffee', '', 'bold')
 call s:HL('cssColor', 'toffee', '', 'bold')


### PR DESCRIPTION
Hello,

Here is a patch to add an option to toggle CSS properties highlighting. I use it mainly to catch typos, as unsupported CSS properties are not highlighted.

Before (off) / After (on):

![](http://f.cl.ly/items/2v1l2Q2M0u150z0E0U2a/hi_css_props.png)
