### PR TITLE
LaTeX support added

### DIFF
--- a/colors/badwolf.vim
+++ b/colors/badwolf.vim
@@ -242,7 +242,6 @@ call s:HL('Repeat',      'taffy', '', 'none')
 " Functions and variable declarations are orange, because plain looks weird.
 call s:HL('Identifier', 'orange', '', 'none')
 call s:HL('Function',   'orange', '', 'none')
-call s:HL('Delimiter',   'orange', '', 'none')
 
 " Preprocessor stuff is lime, to make it pop.
 "
@@ -485,6 +484,8 @@ call s:HL('texMathZoneB', 'orange', '', 'none')
 call s:HL('texMathZoneC', 'orange', '', 'none')
 call s:HL('texMathZoneD', 'orange', '', 'none')
 call s:HL('texMathZoneE', 'orange', '', 'none')
+call s:HL('texMathZoneV', 'orange', '', 'none')
+call s:HL('texMathZoneX', 'orange', '', 'none')
 call s:HL('texMath', 'orange', '', 'none')
 call s:HL('texMathMatcher', 'orange', '', 'none')
 call s:HL('texRefLabel', 'dirtyblonde', '', 'none')


### PR DESCRIPTION
This should close issue 3.

I've finally got the time to understand how to add support for LaTeX.

Note: for how the LaTeX suite works in Vim, I had to add

```
call s:HL('Delimiter',   'tardis', '', 'none')
```

that is not strictly related to LaTeX but which I hope is not
a problem.

Edit: here's the screenshots.

Before

![Before](http://www.ilorentz.org/~gio/public//images/screen2.png)

After

![After](http://www.ilorentz.org/~gio/public//images/screen1.png)
