### PR TITLE
Changed the color of highlighted props in CSS

### DIFF
--- a/colors/badwolf.vim
+++ b/colors/badwolf.vim
@@ -446,11 +446,11 @@ call s:HL('clojureAnonArg', 'snow', '', 'bold')
 " CSS {{{
 
 if g:badwolf_css_props_highlight
-    call s:HL('cssColorProp', 'dirtyblonde', '', 'none')
-    call s:HL('cssBoxProp', 'dirtyblonde', '', 'none')
-    call s:HL('cssTextProp', 'dirtyblonde', '', 'none')
-    call s:HL('cssRenderProp', 'dirtyblonde', '', 'none')
-    call s:HL('cssGeneratedContentProp', 'dirtyblonde', '', 'none')
+    call s:HL('cssColorProp', 'taffy', '', 'none')
+    call s:HL('cssBoxProp', 'taffy', '', 'none')
+    call s:HL('cssTextProp', 'taffy', '', 'none')
+    call s:HL('cssRenderProp', 'taffy', '', 'none')
+    call s:HL('cssGeneratedContentProp', 'taffy', '', 'none')
 else
     call s:HL('cssColorProp', 'fg', '', 'none')
     call s:HL('cssBoxProp', 'fg', '', 'none')


### PR DESCRIPTION
Fixes #15 whenever you set `g:badwolf_css_props_highlight = 1`.

Before:
![](https://dl.dropboxusercontent.com/u/97752/Screenshot%202014-05-27%2009.49.03.png)

After:
![](https://dl.dropboxusercontent.com/u/97752/Screenshot%202014-05-27%2009.48.39.png)