### PR TITLE
Fixed ErrorMsg highlight issue

### DIFF
--- a/colors/badwolf.vim
+++ b/colors/badwolf.vim
@@ -211,7 +211,7 @@ call s:HL('Directory', 'dirtyblonde', '', 'bold')
 
 call s:HL('Title', 'lime')
 
-call s:HL('ErrorMsg',   'taffy',       'bg', 'bold')
+call s:HL('ErrorMsg',   'taffy',       '', 'bold')
 call s:HL('MoreMsg',    'dalespale',   '',   'bold')
 call s:HL('ModeMsg',    'dirtyblonde', '',   'bold')
 call s:HL('Question',   'dirtyblonde', '',   'bold')

--- a/colors/badwolf.vim
+++ b/colors/badwolf.vim
@@ -226,7 +226,7 @@ call s:HL('Tag', '', '', 'bold')
 " }}}
 " Gutter {{{
 
-call s:HL('LineNr',     'mediumgravel', s:gutter)
+call s:HL('LineNr',     'brightgravel', 'darkgravel')
 call s:HL('SignColumn', '',             s:gutter)
 call s:HL('FoldColumn', 'mediumgravel', s:gutter)
 

--- a/colors/badwolf.vim
+++ b/colors/badwolf.vim
@@ -204,8 +204,8 @@ call s:HL('IncSearch', 'coal', 'tardis',    'bold')
 
 call s:HL('Underlined', 'fg', '', 'underline')
 
-call s:HL('StatusLine',   'coal', 'tardis',     'bold')
-call s:HL('StatusLineNC', 'snow', 'deepgravel', 'bold')
+call s:HL('StatusLine',   'lime', 'darkgravel',     'bold')
+call s:HL('StatusLineNC', 'snow', 'darkgravel', 'bold')
 
 call s:HL('Directory', 'dirtyblonde', '', 'bold')
 

--- a/colors/badwolf.vim
+++ b/colors/badwolf.vim
@@ -310,9 +310,9 @@ call s:HL('PmenuThumb', 'brightgravel')
 " }}}
 " Diffs {{{
 
-call s:HL('DiffDelete', 'coal', 'coal')
-call s:HL('DiffAdd',    '',     'deepergravel')
-call s:HL('DiffChange', '',     'darkgravel')
+call s:HL('DiffDelete', 'coal', 'taffy')
+call s:HL('DiffAdd',    'coal',     'lime')
+call s:HL('DiffChange', 'coal',     'orange')
 call s:HL('DiffText',   'snow', 'deepergravel', 'bold')
 
 " }}}


### PR DESCRIPTION
I found that using this match [match ErrorMsg '\s\+$']  for trailing whitespaces error highlighting does not work.

Here a C code before change:
http://i.imgur.com/WSEysYj.png

Here after change (ErrorMsg highlighted correctly):
http://i.imgur.com/pjbNou0.png

Now ErrorMsg highlight works (tested in terminal vim)