### PR TITLE
Fix colors_name to g:colors_name instead

### DIFF
--- a/colors/badwolf.vim
+++ b/colors/badwolf.vim
@@ -41,7 +41,7 @@ if exists("syntax_on")
     syntax reset
 endif
 
-let colors_name = "badwolf"
+let g:colors_name = "badwolf"
 
 if !exists("g:badwolf_html_link_underline") " {{{
     let g:badwolf_html_link_underline = 1


### PR DESCRIPTION
This causes vim to properly reload the correct theme when needed.

Fixes issue #22