### PR TITLE
Adding Javascript es6 support (vim-javascript)

### DIFF
--- a/colors/badwolf.vim
+++ b/colors/badwolf.vim
@@ -185,7 +185,7 @@ endif
 
 call s:HL('Normal', 'plain', 'blackgravel')
 
-call s:HL('Folded', 'mediumgravel', 'bg', 'none')
+call s:HL('Folded', 'darkroast', 'bg', 'none')
 
 call s:HL('VertSplit', 'lightgravel', 'bg', 'none')
 

--- a/colors/badwolf.vim
+++ b/colors/badwolf.vim
@@ -533,6 +533,28 @@ call s:HL('javaDocTags', 'snow', '', 'none')
 call s:HL('javaDocParam', 'dalespale', '', '')
 
 " }}}
+" Javascript {{{
+
+" Imports && Exports
+call s:HL('jsModuleGroup', 'snow', '', 'none')
+call s:HL('jsImportContainer', 'brightgravel', '', 'none')
+call s:HL('jsExportContainer', 'brightgravel', '', 'none')
+
+" Template strings
+call s:HL('jsTemplateString', 'orange', '', 'none')
+call s:HL('jsTemplateVar', 'saltwatertaffy', '', 'none')
+
+" Objects
+call s:HL('jsObjectKey', 'dalespale', '', 'none')
+
+" Keywords
+call s:HL('jsThis', 'taffy', '', 'none')
+call s:HL('jsSuper', 'taffy', '', 'none')
+
+" Functions
+call s:HL('jsFuncArgs', 'saltwatertaffy', '', 'none')
+
+" }}}
 " LaTeX {{{
 
 call s:HL('texStatement', 'tardis', '', 'none')

--- a/colors/badwolf.vim
+++ b/colors/badwolf.vim
@@ -541,11 +541,12 @@ call s:HL('jsImportContainer', 'brightgravel', '', 'none')
 call s:HL('jsExportContainer', 'brightgravel', '', 'none')
 
 " Template strings
-call s:HL('jsTemplateString', 'orange', '', 'none')
+call s:HL('jsTemplateString', 'coffee', '', 'none')
 call s:HL('jsTemplateVar', 'saltwatertaffy', '', 'none')
 
 " Objects
-call s:HL('jsObjectKey', 'dalespale', '', 'none')
+call s:HL('jsObjectKey', 'brightgravel', '', 'none')
+call s:HL('jsObjectValue', 'brightgravel', '', 'none')
 
 " Keywords
 call s:HL('jsThis', 'taffy', '', 'none')


### PR DESCRIPTION
I've added some quick colours for es6 syntax definitions, to make writing React / es6 javascript apps a bit nicer.

Would appreciate feedback on colour combinations, if there are any. Thought I would open a PR in case this was useful for more than just me.

Sample v4.x node.js script with these additions:

![image](https://cloud.githubusercontent.com/assets/7990316/19766548/8179c45c-9c46-11e6-9f39-f07f06de6fa1.png)

Before: 

![image](https://cloud.githubusercontent.com/assets/7990316/19768079/ca97fd3c-9c4d-11e6-99e8-ce3b083654bf.png)

(I'm using mac vim inside the terminal, incase there's any questions about colour idiosyncrasies.)
