### PR TITLE
Minor adjustments to address printing (:hardcopy)

### DIFF
--- a/colors/badwolf.vim
+++ b/colors/badwolf.vim
@@ -232,7 +232,7 @@ call s:HL('Tag', '', '', 'bold')
 " }}}
 " Gutter {{{
 
-call s:HL('LineNr',     'mediumgravel', s:gutter)
+call s:HL('LineNr',     'mediumgravel')
 call s:HL('SignColumn', '',             s:gutter)
 call s:HL('FoldColumn', 'mediumgravel', s:gutter)
 

--- a/colors/goodwolf.vim
+++ b/colors/goodwolf.vim
@@ -207,7 +207,7 @@ call s:HL('Tag', '', '', 'bold')
 " }}}
 " Gutter {{{
 
-call s:HL('LineNr',     'mediumgravel', s:gutter)
+call s:HL('LineNr',     'mediumgravel')
 call s:HL('SignColumn', '',             s:gutter)
 call s:HL('FoldColumn', 'mediumgravel', s:gutter)
 

--- a/colors/goodwolf.vim
+++ b/colors/goodwolf.vim
@@ -225,7 +225,7 @@ call s:HL('iCursor', 'coal', 'tardis', 'none')
 call s:HL('Special', 'plain')
 
 " Comments are slightly brighter than folds, to make 'headers' easier to see.
-call s:HL('Comment',        'gravel', 'bg', 'none')
+call s:HL('Comment',        'gravel')
 call s:HL('Todo',           'snow',   'bg', 'bold')
 call s:HL('SpecialComment', 'snow',   'bg', 'bold')
 


### PR DESCRIPTION
Even though minor, I've split these changes into two commits former of which should hopefully cause no controversy. Latter seems to yield the same result, even though is also only a partial fix.

Problem:
When printing (:hardcopy), having explicitly set background color for line numbering (even though the same color as Normal backgroud), vim would no longer works its magic on darkscheme for that region of the page resulting in large dark block. Leaving the background unset (inherited) address that.

Similar story goes for comment. Badwolf was already leaving this untouched, I've done the same for Goodwolf now. Resulting highlight seems to be the same for Comment.

Open Issue(s):
Latter still does not address Todo and SpecialComment. I've played around changing s:HL to simply not add any background when 'bg' is given, but then for instance Todo ends with its default of yellow. Or alternatively introducing another keyword alongside 'bg' to simply ignore setting backgound... but that doesn't help Todo and on top of that did not look a bit ugly/hackish.