### PR TITLE
Add config option to change folded line bg

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -50,6 +50,26 @@ darker than the normal background, or the same.
 
 Default: `0` (off, gutters are the same as the background)
 
+### g:badwolf\_folded
+
+Determines how light to render the background of folded linese.
+
+Can be set to `0`, `1`, `2`, or `3`.
+
+    " Make folded lines darker than the background.
+    let g:badwolf_folded = 0
+
+    " Make folded lines the same color as the background.
+    let g:badwolf_folded = 1
+
+    " Make folded lines lighter than the background.
+    let g:badwolf_folded = 2
+
+    " Make folded lines much lighter than the background.
+    let g:badwolf_folded = 3
+
+Default: `1` (same color as the background)
+
 ### g:badwolf\_tabline
 
 Determines how light to render the background of the tab line (the line at the

--- a/colors/badwolf.vim
+++ b/colors/badwolf.vim
@@ -160,6 +160,22 @@ else
     let s:gutter = 'blackgravel'
 endif
 
+if exists('g:badwolf_folded')
+    if g:badwolf_folded == 0
+        let s:folded = 'blackestgravel'
+    elseif  g:badwolf_folded == 1
+        let s:folded = 'blackgravel'
+    elseif  g:badwolf_folded == 2
+        let s:folded = 'darkgravel'
+    elseif  g:badwolf_folded == 3
+        let s:folded = 'deepgravel'
+    else
+        let s:folded = 'blackestgravel'
+    endif
+else
+    let s:folded = 'blackgravel'
+endif
+
 if exists('g:badwolf_tabline')
     if g:badwolf_tabline == 0
         let s:tabline = 'blackestgravel'
@@ -185,7 +201,7 @@ endif
 
 call s:HL('Normal', 'plain', 'blackgravel')
 
-call s:HL('Folded', 'mediumgravel', 'bg', 'none')
+call s:HL('Folded', 'mediumgravel', s:folded, 'none')
 
 call s:HL('VertSplit', 'lightgravel', 'bg', 'none')
 

--- a/colors/goodwolf.vim
+++ b/colors/goodwolf.vim
@@ -139,6 +139,22 @@ else
     let s:gutter = 'blackgravel'
 endif
 
+if exists('g:badwolf_folded')
+    if g:badwolf_folded == 0
+        let s:folded = 'blackestgravel'
+    elseif  g:badwolf_folded == 1
+        let s:folded = 'blackgravel'
+    elseif  g:badwolf_folded == 2
+        let s:folded = 'darkgravel'
+    elseif  g:badwolf_folded == 3
+        let s:folded = 'deepgravel'
+    else
+        let s:folded = 'blackestgravel'
+    endif
+else
+    let s:folded = 'blackgravel'
+endif
+
 if exists('g:badwolf_tabline')
     if g:badwolf_tabline == 0
         let s:tabline = 'blackestgravel'
@@ -165,7 +181,7 @@ endif
 " call GoodWolfHL('Normal', 'plain', 'blackgravel')
 call GoodWolfHL('Normal', 'plain', 'blackestgravel')
 
-call GoodWolfHL('Folded', 'mediumgravel', 'bg', 'none')
+call GoodWolfHL('Folded', 'mediumgravel', s:folded, 'none')
 
 call GoodWolfHL('VertSplit', 'lightgravel', 'bg', 'none')
 


### PR DESCRIPTION
I love the colorscheme, but I found that sometimes I would lose track of code folds as they blend into the background. So I decided to add a configuration option (`badwolf_folded`) to adjust the background color in a similar manner to the tabline. It defaults to no change, so existing users won't be affected negatively.

Side-by-side-by-side-by-side image for comparison (`badwolf_folded` values are `0`, `1` [default], `2`, and `3`, respectively): https://imgur.com/a/LyMxdAI