### PR TITLE
Align :terminal status colour to editor status line colour.

### DIFF
--- a/colors/badwolf.vim
+++ b/colors/badwolf.vim
@@ -212,6 +212,8 @@ call s:HL('Underlined', 'fg', '', 'underline')
 
 call s:HL('StatusLine',   'coal', 'tardis',     'bold')
 call s:HL('StatusLineNC', 'snow', 'deepgravel', 'bold')
+call s:HL('StatusLineTerm',   'coal', 'tardis',     'bold')
+call s:HL('StatusLineTermNC', 'snow', 'deepgravel', 'bold')
 
 call s:HL('Directory', 'dirtyblonde', '', 'bold')
 


### PR DESCRIPTION
Just an idea to align the :terminal status line colour to makes it easier to see which tab is active when you have split terminal window.   

Thanks for the best vim color scheme, by the way!