### PR TITLE
fix: clear highlights before loading colors

### DIFF
--- a/colors/badwolf.vim
+++ b/colors/badwolf.vim
@@ -35,6 +35,7 @@ if !has("gui_running") && &t_Co != 88 && &t_Co != 256
     finish
 endif
 
+highlight clear
 set background=dark
 
 if exists("syntax_on")

--- a/colors/goodwolf.vim
+++ b/colors/goodwolf.vim
@@ -19,6 +19,7 @@ if !has("gui_running") && &t_Co != 88 && &t_Co != 256
     finish
 endif
 
+highlight clear
 set background=dark
 
 if exists("syntax_on")


### PR DESCRIPTION
Related issue: #47 

If a user has custom highlights set up for other colorschemes, and then switches to badwolf, these highlights are not properly cleared.

This causes badwolf to be displayed incorrectly, e.g., like in the following screenshot:

![Before](https://github.com/user-attachments/assets/8fc3c25a-e958-49e5-8f97-cc649c6e9a18)

The issue is fixed by calling `highlight clear` before setting up the colors, which causes badwolf to be displayed properly:

![After](https://github.com/user-attachments/assets/abd865a7-804d-4e3e-8246-1e475d9fd7ec)


